### PR TITLE
Refactor WinForms client into layered architecture

### DIFF
--- a/BE/Consumo2WebAPIRENIEC.BE.csproj
+++ b/BE/Consumo2WebAPIRENIEC.BE.csproj
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C74EF4F7-08E3-4D68-BC48-5571CE60817B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Consumo2WebAPIRENIEC.BE</RootNamespace>
+    <AssemblyName>Consumo2WebAPIRENIEC.BE</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\\Debug\\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\\Release\\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\\packages\\Newtonsoft.Json.13.0.4\\lib\\net45\\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Entities\ReniecConsultaRequest.cs" />
+    <Compile Include="Entities\ReniecConsultaResponse.cs" />
+    <Compile Include="Entities\ReniecCiudadano.cs" />
+    <Compile Include="Entities\ReniecAfiliacion.cs" />
+    <Compile Include="Entities\ReniecAdhesion.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BE/Entities/ReniecAdhesion.cs
+++ b/BE/Entities/ReniecAdhesion.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace Consumo2WebAPIRENIEC.BE.Entities
+{
+    public sealed class ReniecAdhesion
+    {
+        [JsonProperty("dni")]
+        public string Dni { get; set; }
+
+        [JsonProperty("id_unico")]
+        public string IdUnico { get; set; }
+
+        [JsonProperty("fecha_adhesion")]
+        public string FechaAdhesion { get; set; }
+
+        [JsonProperty("codOp")]
+        public string CodigoOperacion { get; set; }
+
+        [JsonProperty("ficha_adhesion")]
+        public string FichaAdhesion { get; set; }
+    }
+}

--- a/BE/Entities/ReniecAfiliacion.cs
+++ b/BE/Entities/ReniecAfiliacion.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace Consumo2WebAPIRENIEC.BE.Entities
+{
+    public sealed class ReniecAfiliacion
+    {
+        [JsonProperty("dni")]
+        public string Dni { get; set; }
+
+        [JsonProperty("id_unico")]
+        public string IdUnico { get; set; }
+
+        [JsonProperty("fecha_afiliacion")]
+        public string FechaAfiliacion { get; set; }
+
+        [JsonProperty("codOp")]
+        public string CodigoOperacion { get; set; }
+
+        [JsonProperty("ficha_afiliacion")]
+        public string FichaAfiliacion { get; set; }
+    }
+}

--- a/BE/Entities/ReniecCiudadano.cs
+++ b/BE/Entities/ReniecCiudadano.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Consumo2WebAPIRENIEC.BE.Entities
+{
+    public sealed class ReniecCiudadano
+    {
+        [JsonProperty("documento")]
+        public string NumeroDocumento { get; set; }
+
+        [JsonProperty("nombreCompleto")]
+        public string NombreCompleto { get; set; }
+
+        [JsonProperty("estadoCivil")]
+        public string EstadoCivil { get; set; }
+
+        [JsonProperty("ubigeo")]
+        public string UbigeoDireccion { get; set; }
+
+        [JsonProperty("afiliaciones")]
+        public List<ReniecAfiliacion> Afiliaciones { get; set; } = new List<ReniecAfiliacion>();
+
+        [JsonProperty("adhesiones")]
+        public List<ReniecAdhesion> Adhesiones { get; set; } = new List<ReniecAdhesion>();
+    }
+}

--- a/BE/Entities/ReniecConsultaRequest.cs
+++ b/BE/Entities/ReniecConsultaRequest.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Consumo2WebAPIRENIEC.BE.Entities
+{
+    public sealed class ReniecConsultaRequest
+    {
+        [JsonProperty("tipoDocumento")]
+        public string TipoDocumento { get; set; }
+
+        [JsonProperty("numeroDocumento")]
+        public string NumeroDocumento { get; set; }
+
+        [JsonProperty("canal")]
+        public string Canal { get; set; }
+    }
+}

--- a/BE/Entities/ReniecConsultaResponse.cs
+++ b/BE/Entities/ReniecConsultaResponse.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Consumo2WebAPIRENIEC.BE.Entities
+{
+    public sealed class ReniecConsultaResponse
+    {
+        [JsonProperty("success")]
+        public bool Exito { get; set; }
+
+        [JsonProperty("message")]
+        public string Mensaje { get; set; }
+
+        [JsonProperty("data")]
+        public ReniecCiudadano Resultado { get; set; }
+    }
+}

--- a/BE/Properties/AssemblyInfo.cs
+++ b/BE/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Consumo2WebAPIRENIEC.BE")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Consumo2WebAPIRENIEC.BE")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("e8a26836-c8ad-4ee1-826d-c86c2981e999")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BE/packages.config
+++ b/BE/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
+</packages>

--- a/BL/Consumo2WebAPIRENIEC.BL.csproj
+++ b/BL/Consumo2WebAPIRENIEC.BL.csproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CB3A863C-D753-4A88-8E8B-7F00944C413F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Consumo2WebAPIRENIEC.BL</RootNamespace>
+    <AssemblyName>Consumo2WebAPIRENIEC.BL</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\\Debug\\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\\Release\\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Formatting\ReniecFormatter.cs" />
+    <Compile Include="Services\ReniecService.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\BE\\Consumo2WebAPIRENIEC.BE.csproj">
+      <Project>{C74EF4F7-08E3-4D68-BC48-5571CE60817B}</Project>
+      <Name>Consumo2WebAPIRENIEC.BE</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\\DA\\Consumo2WebAPIRENIEC.DA.csproj">
+      <Project>{5FA9F2F2-EE98-4E93-A210-CC912072E641}</Project>
+      <Name>Consumo2WebAPIRENIEC.DA</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BL/Formatting/ReniecFormatter.cs
+++ b/BL/Formatting/ReniecFormatter.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using Consumo2WebAPIRENIEC.BE.Entities;
+
+namespace Consumo2WebAPIRENIEC.BL.Formatting
+{
+    public static class ReniecFormatter
+    {
+        public static string FormatearCiudadano(ReniecCiudadano ciudadano)
+        {
+            if (ciudadano == null)
+            {
+                return string.Empty;
+            }
+
+            var lineas = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(ciudadano.NumeroDocumento))
+            {
+                lineas.Add("Documento: " + ciudadano.NumeroDocumento);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ciudadano.NombreCompleto))
+            {
+                lineas.Add("Nombre: " + ciudadano.NombreCompleto);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ciudadano.EstadoCivil))
+            {
+                lineas.Add("Estado civil: " + ciudadano.EstadoCivil);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ciudadano.UbigeoDireccion))
+            {
+                lineas.Add("Ubigeo: " + ciudadano.UbigeoDireccion);
+            }
+
+            AgregarAfiliaciones(ciudadano, lineas);
+            AgregarAdhesiones(ciudadano, lineas);
+
+            return string.Join(Environment.NewLine, lineas);
+        }
+
+        private static void AgregarAfiliaciones(ReniecCiudadano ciudadano, List<string> lineas)
+        {
+            if (ciudadano.Afiliaciones == null || ciudadano.Afiliaciones.Count == 0)
+            {
+                return;
+            }
+
+            lineas.Add("Afiliaciones:");
+            for (int i = 0; i < ciudadano.Afiliaciones.Count; i++)
+            {
+                AgregarDetalleAfiliacion(lineas, ciudadano.Afiliaciones[i], i + 1);
+            }
+        }
+
+        private static void AgregarDetalleAfiliacion(List<string> lineas, ReniecAfiliacion afiliacion, int indice)
+        {
+            if (afiliacion == null)
+            {
+                return;
+            }
+
+            lineas.Add(string.Format("  {0}. DNI: {1}", indice, ObtenerValor(afiliacion.Dni)));
+            lineas.Add("      ID único: " + ObtenerValor(afiliacion.IdUnico));
+            lineas.Add("      Fecha afiliación: " + ObtenerValor(afiliacion.FechaAfiliacion));
+            lineas.Add("      Código operación: " + ObtenerValor(afiliacion.CodigoOperacion));
+            lineas.Add("      Ficha: " + ObtenerValor(afiliacion.FichaAfiliacion));
+        }
+
+        private static void AgregarAdhesiones(ReniecCiudadano ciudadano, List<string> lineas)
+        {
+            if (ciudadano.Adhesiones == null || ciudadano.Adhesiones.Count == 0)
+            {
+                return;
+            }
+
+            lineas.Add("Adhesiones:");
+            for (int i = 0; i < ciudadano.Adhesiones.Count; i++)
+            {
+                AgregarDetalleAdhesion(lineas, ciudadano.Adhesiones[i], i + 1);
+            }
+        }
+
+        private static void AgregarDetalleAdhesion(List<string> lineas, ReniecAdhesion adhesion, int indice)
+        {
+            if (adhesion == null)
+            {
+                return;
+            }
+
+            lineas.Add(string.Format("  {0}. DNI: {1}", indice, ObtenerValor(adhesion.Dni)));
+            lineas.Add("      ID único: " + ObtenerValor(adhesion.IdUnico));
+            lineas.Add("      Fecha adhesión: " + ObtenerValor(adhesion.FechaAdhesion));
+            lineas.Add("      Código operación: " + ObtenerValor(adhesion.CodigoOperacion));
+            lineas.Add("      Ficha: " + ObtenerValor(adhesion.FichaAdhesion));
+        }
+
+        private static string ObtenerValor(string valor)
+        {
+            return string.IsNullOrWhiteSpace(valor) ? "(sin dato)" : valor;
+        }
+    }
+}

--- a/BL/Properties/AssemblyInfo.cs
+++ b/BL/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Consumo2WebAPIRENIEC.BL")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Consumo2WebAPIRENIEC.BL")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("1bf0aafb-48b4-4a7b-8b0d-e8d815b67925")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BL/Services/ReniecService.cs
+++ b/BL/Services/ReniecService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using Consumo2WebAPIRENIEC.BE.Entities;
+using Consumo2WebAPIRENIEC.DA.Services;
+
+namespace Consumo2WebAPIRENIEC.BL.Services
+{
+    public class ReniecService
+    {
+        private readonly ReniecApiClient _reniecApiClient;
+
+        public ReniecService()
+            : this(new ReniecApiClient())
+        {
+        }
+
+        public ReniecService(ReniecApiClient reniecApiClient)
+        {
+            if (reniecApiClient == null)
+            {
+                throw new ArgumentNullException("reniecApiClient");
+            }
+
+            _reniecApiClient = reniecApiClient;
+        }
+
+        public Task<ReniecConsultaResponse> ConsultarCiudadanoAsync(ReniecConsultaRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            return _reniecApiClient.ConsultarAsync(request);
+        }
+    }
+}

--- a/Consumo2WebAPIRENIEC.csproj
+++ b/Consumo2WebAPIRENIEC.csproj
@@ -83,5 +83,15 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="BL\Consumo2WebAPIRENIEC.BL.csproj">
+      <Project>{CB3A863C-D753-4A88-8E8B-7F00944C413F}</Project>
+      <Name>Consumo2WebAPIRENIEC.BL</Name>
+    </ProjectReference>
+    <ProjectReference Include="BE\Consumo2WebAPIRENIEC.BE.csproj">
+      <Project>{C74EF4F7-08E3-4D68-BC48-5571CE60817B}</Project>
+      <Name>Consumo2WebAPIRENIEC.BE</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Consumo2WebAPIRENIEC.sln
+++ b/Consumo2WebAPIRENIEC.sln
@@ -5,17 +5,41 @@ VisualStudioVersion = 17.14.36408.4 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumo2WebAPIRENIEC", "Consumo2WebAPIRENIEC.csproj", "{ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumo2WebAPIRENIEC.BE", "BE\\Consumo2WebAPIRENIEC.BE.csproj", "{C74EF4F7-08E3-4D68-BC48-5571CE60817B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumo2WebAPIRENIEC.DA", "DA\\Consumo2WebAPIRENIEC.DA.csproj", "{5FA9F2F2-EE98-4E93-A210-CC912072E641}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumo2WebAPIRENIEC.BL", "BL\\Consumo2WebAPIRENIEC.BL.csproj", "{CB3A863C-D753-4A88-8E8B-7F00944C413F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Consumo2WebAPIRENIEC.Utilitario", "Utilitario\\Consumo2WebAPIRENIEC.Utilitario.csproj", "{70D07F50-056A-4B61-888F-144FECC4D565}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {ABBB73B2-33C0-421D-ABB1-3D6CC3CB04AB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C74EF4F7-08E3-4D68-BC48-5571CE60817B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C74EF4F7-08E3-4D68-BC48-5571CE60817B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C74EF4F7-08E3-4D68-BC48-5571CE60817B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C74EF4F7-08E3-4D68-BC48-5571CE60817B}.Release|Any CPU.Build.0 = Release|Any CPU
+                {5FA9F2F2-EE98-4E93-A210-CC912072E641}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {5FA9F2F2-EE98-4E93-A210-CC912072E641}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {5FA9F2F2-EE98-4E93-A210-CC912072E641}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {5FA9F2F2-EE98-4E93-A210-CC912072E641}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CB3A863C-D753-4A88-8E8B-7F00944C413F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CB3A863C-D753-4A88-8E8B-7F00944C413F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CB3A863C-D753-4A88-8E8B-7F00944C413F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CB3A863C-D753-4A88-8E8B-7F00944C413F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {70D07F50-056A-4B61-888F-144FECC4D565}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {70D07F50-056A-4B61-888F-144FECC4D565}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {70D07F50-056A-4B61-888F-144FECC4D565}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {70D07F50-056A-4B61-888F-144FECC4D565}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/DA/Consumo2WebAPIRENIEC.DA.csproj
+++ b/DA/Consumo2WebAPIRENIEC.DA.csproj
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5FA9F2F2-EE98-4E93-A210-CC912072E641}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Consumo2WebAPIRENIEC.DA</RootNamespace>
+    <AssemblyName>Consumo2WebAPIRENIEC.DA</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\\Debug\\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\\Release\\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\\packages\\Newtonsoft.Json.13.0.4\\lib\\net45\\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Services\ReniecApiClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\BE\\Consumo2WebAPIRENIEC.BE.csproj">
+      <Project>{C74EF4F7-08E3-4D68-BC48-5571CE60817B}</Project>
+      <Name>Consumo2WebAPIRENIEC.BE</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\\Utilitario\\Consumo2WebAPIRENIEC.Utilitario.csproj">
+      <Project>{70D07F50-056A-4B61-888F-144FECC4D565}</Project>
+      <Name>Consumo2WebAPIRENIEC.Utilitario</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/DA/Properties/AssemblyInfo.cs
+++ b/DA/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Consumo2WebAPIRENIEC.DA")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Consumo2WebAPIRENIEC.DA")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("220359f7-41da-4f27-8f16-57795b9340f0")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DA/Services/ReniecApiClient.cs
+++ b/DA/Services/ReniecApiClient.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Consumo2WebAPIRENIEC.BE.Entities;
+using Consumo2WebAPIRENIEC.Utilitario.Http;
+using Newtonsoft.Json;
+
+namespace Consumo2WebAPIRENIEC.DA.Services
+{
+    public class ReniecApiClient
+    {
+        private const string ConsultaReniecEndpoint = "api/reniec/consulta";
+        private readonly HttpClient _httpClient;
+
+        public ReniecApiClient()
+            : this(HttpClientProvider.GetReniecClient())
+        {
+        }
+
+        public ReniecApiClient(HttpClient httpClient)
+        {
+            if (httpClient == null)
+            {
+                throw new ArgumentNullException("httpClient");
+            }
+
+            _httpClient = httpClient;
+        }
+
+        public async Task<ReniecConsultaResponse> ConsultarAsync(ReniecConsultaRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            string cuerpo = JsonConvert.SerializeObject(request);
+
+            using (var contenido = new StringContent(cuerpo, Encoding.UTF8, "application/json"))
+            using (HttpResponseMessage respuesta = await _httpClient.PostAsync(ConsultaReniecEndpoint, contenido).ConfigureAwait(false))
+            {
+                string contenidoRespuesta = await respuesta.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                if (!respuesta.IsSuccessStatusCode)
+                {
+                    throw new HttpRequestException(string.Format("Error {0}: {1}", (int)respuesta.StatusCode, contenidoRespuesta));
+                }
+
+                if (string.IsNullOrWhiteSpace(contenidoRespuesta))
+                {
+                    return null;
+                }
+
+                return JsonConvert.DeserializeObject<ReniecConsultaResponse>(contenidoRespuesta);
+            }
+        }
+    }
+}

--- a/DA/packages.config
+++ b/DA/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
+</packages>

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,43 +1,74 @@
-﻿using System;
+using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
-
-
+using Consumo2WebAPIRENIEC.BE.Entities;
+using Consumo2WebAPIRENIEC.BL.Formatting;
+using Consumo2WebAPIRENIEC.BL.Services;
 
 namespace Consumo2WebAPIRENIEC
 {
     public partial class Form1 : Form
     {
-        private static readonly HttpClient _httpClient;
-
-        static Form1()
-        {
-            _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://pkioc.reniec.gob.pe/afiliacionpp/backend-afiliacion/")
-            };
-            _httpClient.Timeout = TimeSpan.FromSeconds(15);
-        }
+        private readonly ReniecService _reniecService;
 
         public Form1()
         {
             InitializeComponent();
+            _reniecService = new ReniecService();
         }
 
         private async void button1_Click(object sender, EventArgs e)
         {
-            
+            button1.Enabled = false;
+
+            try
+            {
+                var request = new ReniecConsultaRequest
+                {
+                    Canal = "ESCRITORIO",
+                    NumeroDocumento = "00000000",
+                    TipoDocumento = "DNI"
+                };
+
+                ReniecConsultaResponse response = await _reniecService.ConsultarCiudadanoAsync(request).ConfigureAwait(true);
+
+                if (response == null)
+                {
+                    MessageBox.Show("La respuesta de la API no contiene datos.", "RENIEC", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                if (!response.Exito)
+                {
+                    MessageBox.Show(string.IsNullOrEmpty(response.Mensaje) ? "La API devolvió un error." : response.Mensaje, "RENIEC", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                if (response.Resultado == null)
+                {
+                    MessageBox.Show("No se encontraron datos del ciudadano.", "RENIEC", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
+
+                MessageBox.Show(ReniecFormatter.FormatearCiudadano(response.Resultado), "RENIEC", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (HttpRequestException httpEx)
+            {
+                MessageBox.Show("Se produjo un error de comunicación con RENIEC: " + httpEx.Message, "RENIEC", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            catch (TaskCanceledException)
+            {
+                MessageBox.Show("La consulta excedió el tiempo máximo de espera configurado.", "RENIEC", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Se produjo un error inesperado: " + ex.Message, "RENIEC", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                button1.Enabled = true;
+            }
         }
-
-      
-
-     
-
-    
-
-       
     }
 }

--- a/Utilitario/Consumo2WebAPIRENIEC.Utilitario.csproj
+++ b/Utilitario/Consumo2WebAPIRENIEC.Utilitario.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{70D07F50-056A-4B61-888F-144FECC4D565}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Consumo2WebAPIRENIEC.Utilitario</RootNamespace>
+    <AssemblyName>Consumo2WebAPIRENIEC.Utilitario</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\\Debug\\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\\Release\\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Http\HttpClientProvider.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Utilitario/Http/HttpClientProvider.cs
+++ b/Utilitario/Http/HttpClientProvider.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace Consumo2WebAPIRENIEC.Utilitario.Http
+{
+    public static class HttpClientProvider
+    {
+        private static readonly Lazy<HttpClient> _reniecClient = new Lazy<HttpClient>(CreateReniecClient, true);
+
+        public static HttpClient GetReniecClient()
+        {
+            return _reniecClient.Value;
+        }
+
+        private static HttpClient CreateReniecClient()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
+            var client = new HttpClient
+            {
+                BaseAddress = new Uri("https://pkioc.reniec.gob.pe/afiliacionpp/backend-afiliacion/")
+            };
+
+            client.Timeout = TimeSpan.FromSeconds(15);
+
+            return client;
+        }
+    }
+}

--- a/Utilitario/Properties/AssemblyInfo.cs
+++ b/Utilitario/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Consumo2WebAPIRENIEC.Utilitario")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Consumo2WebAPIRENIEC.Utilitario")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("a996ba40-7a5f-4fb6-94d8-f26c3a479853")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
## Summary
- add Business Entities, Data Access, Business Layer and Utilitario class libraries to the solution for the RENIEC integration
- move the DTOs, service consumption logic and formatting helpers into their respective layers and keep the WinForms form focused on UI
- update the WinForms project references to consume the new layers and share the Newtonsoft.Json dependency
- enrich the formatter to surface the RENIEC 5.3/5.4 affiliation and adhesion details while defaulting the collections in the entity model

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc32560ff8832ab31b3c706fbd629b