### PR TITLE
Invoke RENIEC JNE afiliacion and adhesion endpoints from button

### DIFF
--- a/BL/Services/ReniecService.cs
+++ b/BL/Services/ReniecService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Consumo2WebAPIRENIEC.BE.Entities;
 using Consumo2WebAPIRENIEC.DA.Services;
@@ -32,6 +33,36 @@ namespace Consumo2WebAPIRENIEC.BL.Services
             }
 
             return _reniecApiClient.ConsultarAsync(request);
+        }
+
+        public Task<IReadOnlyList<ReniecAfiliacion>> ObtenerAfiliacionesAprobadasAsync(string parametro, string token)
+        {
+            if (string.IsNullOrWhiteSpace(parametro))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", "parametro");
+            }
+
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", "token");
+            }
+
+            return _reniecApiClient.ObtenerAfiliacionesAprobadasAsync(parametro, token);
+        }
+
+        public Task<IReadOnlyList<ReniecAdhesion>> ObtenerAdhesionesAsync(string parametro, string token)
+        {
+            if (string.IsNullOrWhiteSpace(parametro))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", "parametro");
+            }
+
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", "token");
+            }
+
+            return _reniecApiClient.ObtenerAdhesionesAsync(parametro, token);
         }
     }
 }

--- a/Consumo2WebAPIRENIEC/Form1.cs
+++ b/Consumo2WebAPIRENIEC/Form1.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Net.Http;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Text;
 using System.Windows.Forms;
 using Consumo2WebAPIRENIEC.BE.Entities;
-using Consumo2WebAPIRENIEC.BL.Formatting;
 using Consumo2WebAPIRENIEC.BL.Services;
 
 namespace Consumo2WebAPIRENIEC
@@ -20,7 +19,78 @@ namespace Consumo2WebAPIRENIEC
 
         private async void button1_Click(object sender, EventArgs e)
         {
+            const string parametro = "IT19";
+            const string token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.stg";
 
+            button1.Enabled = false;
+
+            try
+            {
+                IReadOnlyList<ReniecAfiliacion> afiliaciones = await _reniecService.ObtenerAfiliacionesAprobadasAsync(parametro, token);
+                IReadOnlyList<ReniecAdhesion> adhesiones = await _reniecService.ObtenerAdhesionesAsync(parametro, token);
+
+                var mensaje = new StringBuilder();
+                AgregarDetalleAfiliaciones(mensaje, afiliaciones);
+                mensaje.AppendLine();
+                AgregarDetalleAdhesiones(mensaje, adhesiones);
+
+                MessageBox.Show(mensaje.ToString(), "Resultado", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Ocurrió un error al consultar los servicios: " + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                button1.Enabled = true;
+            }
+        }
+
+        private static void AgregarDetalleAfiliaciones(StringBuilder mensaje, IReadOnlyList<ReniecAfiliacion> afiliaciones)
+        {
+            mensaje.AppendLine("Afiliaciones aprobadas JNE:");
+
+            if (afiliaciones == null || afiliaciones.Count == 0)
+            {
+                mensaje.AppendLine("  (sin registros)");
+                return;
+            }
+
+            for (int i = 0; i < afiliaciones.Count; i++)
+            {
+                ReniecAfiliacion afiliacion = afiliaciones[i];
+                mensaje.AppendLine(string.Format("  {0}. DNI: {1}", i + 1, ObtenerValor(afiliacion?.Dni)));
+                mensaje.AppendLine("      ID único: " + ObtenerValor(afiliacion?.IdUnico));
+                mensaje.AppendLine("      Fecha afiliación: " + ObtenerValor(afiliacion?.FechaAfiliacion));
+                mensaje.AppendLine("      Código operación: " + ObtenerValor(afiliacion?.CodigoOperacion));
+                mensaje.AppendLine("      Ficha: " + ObtenerValor(afiliacion?.FichaAfiliacion));
+            }
+        }
+
+        private static void AgregarDetalleAdhesiones(StringBuilder mensaje, IReadOnlyList<ReniecAdhesion> adhesiones)
+        {
+            mensaje.AppendLine("Adhesiones JNE:");
+
+            if (adhesiones == null || adhesiones.Count == 0)
+            {
+                mensaje.AppendLine("  (sin registros)");
+                return;
+            }
+
+            for (int i = 0; i < adhesiones.Count; i++)
+            {
+                ReniecAdhesion adhesion = adhesiones[i];
+                mensaje.AppendLine(string.Format("  {0}. DNI: {1}", i + 1, ObtenerValor(adhesion?.Dni)));
+                mensaje.AppendLine("      ID único: " + ObtenerValor(adhesion?.IdUnico));
+                mensaje.AppendLine("      Fecha adhesión: " + ObtenerValor(adhesion?.FechaAdhesion));
+                mensaje.AppendLine("      Código operación: " + ObtenerValor(adhesion?.CodigoOperacion));
+                mensaje.AppendLine("      Ficha: " + ObtenerValor(adhesion?.FichaAdhesion));
+            }
+        }
+
+        private static string ObtenerValor(string valor)
+        {
+            return string.IsNullOrWhiteSpace(valor) ? "(sin dato)" : valor;
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend the RENIEC API client to call the afiliaciones aprobadas and adhesiones JNE endpoints with bearer authorization
- expose new business-layer helpers to retrieve afiliaciones and adhesiones by parameter and token
- update the Form1 button click handler to invoke both services with the provided values and present the results in the UI

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ded726aee8832ab6ff41b11170904f